### PR TITLE
Discard messages with Content-Type different than text/plain

### DIFF
--- a/restcomm/restcomm.sms/src/main/java/org/mobicents/servlet/restcomm/sms/SmsService.java
+++ b/restcomm/restcomm.sms/src/main/java/org/mobicents/servlet/restcomm/sms/SmsService.java
@@ -116,6 +116,11 @@ public final class SmsService extends UntypedActor {
         final ActorRef self = self();
         final SipServletRequest request = (SipServletRequest) message;
 
+        // ignore composing messages and accept content type including text only
+        // https://github.com/Mobicents/RestComm/issues/494
+        if (!request.getContentType().contains("text/plain"))
+            return;
+
         final SipURI fromURI = (SipURI) request.getFrom().getURI();
         final String fromUser = fromURI.getUser();
         final ClientsDao clients = storage.getClientsDao();

--- a/restcomm/restcomm.testsuite/src/test/java/org/mobicents/servlet/restcomm/sms/SmsEndpointTool.java
+++ b/restcomm/restcomm.testsuite/src/test/java/org/mobicents/servlet/restcomm/sms/SmsEndpointTool.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.sun.jersey.api.client.Client;
@@ -88,6 +89,18 @@ public class SmsEndpointTool {
         JsonObject jsonObject = parser.parse(response).getAsJsonObject();
 
         return jsonObject;
+    }
+
+    public JsonArray getSmsList(String deploymentUrl, String username, String authToken) {
+        Client jerseyClient = Client.create();
+        jerseyClient.addFilter(new HTTPBasicAuthFilter(username, authToken));
+        String url = getAccountsUrl(deploymentUrl, username, true);
+        WebResource webResource = jerseyClient.resource(url);
+        String response = webResource.accept(MediaType.APPLICATION_JSON).get(String.class);
+        JsonParser parser = new JsonParser();
+        JsonArray jsonArray = null;
+        jsonArray = parser.parse(response).getAsJsonArray();
+        return jsonArray;
     }
 
 }


### PR DESCRIPTION
Discard messages with Content-Type different than text/plain, avoiding exceptions while processing composing messages from Linphone. Issue #494.